### PR TITLE
various updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,7 @@ LearningStrategies provides a generic interface, along with common functionality
 function learn!(model, meta::MetaLearner, data)
     pre_hook(meta, model)
     for (i, item) in enumerate(data)
-        for mgr in meta.managers
-            learn!(model, mgr, item)
-        end
-
+        update!(model, meta, item)
         iter_hook(meta, model, i)
         finished(meta, model, i) && break
     end

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.6.0-pre
+julia 0.6.0
 LearnBase

--- a/src/LearningStrategies.jl
+++ b/src/LearningStrategies.jl
@@ -8,7 +8,7 @@ using LearnBase
 import LearnBase: learn!, update!
 
 export
-    LearningStrategy, MetaLearner, make_learner,
+    LearningStrategy, MetaLearner, make_learner, LearnType,
     # LearningStrategies
     MaxIter, TimeLimit, ConvergenceFunction, IterFunction, ShowStatus, Tracer,
     Converged, ConvergedTo,

--- a/src/LearningStrategies.jl
+++ b/src/LearningStrategies.jl
@@ -5,30 +5,27 @@ module LearningStrategies
 # ----------------------------------------------------------------------
 
 using LearnBase
-import LearnBase: learn!
+import LearnBase: learn!, update!
 
 export
-    LearningStrategy,
-    MetaLearner,
-    make_learner,
-
-    MaxIter,
-    TimeLimit,
-    ConvergenceFunction,
-    IterFunction,
-    ShowStatus,
-    Tracer,
-    Converged,
-    ConvergedTo,
-
-    pre_hook,
-    iter_hook,
-    learn!,
-    post_hook,
-    finished
+    LearningStrategy, MetaLearner, make_learner,
+    # LearningStrategies
+    MaxIter, TimeLimit, ConvergenceFunction, IterFunction, ShowStatus, Tracer,
+    Converged, ConvergedTo,
+    # functions
+    pre_hook, iter_hook, learn!, update!, post_hook, finished
 
 # ----------------------------------------------------------------------
 
+"""
+A LearningStrategy should implement at least one of the following methods:
+
+- `pre_hook(strat, model)`
+- `post_hook(strat, model)`
+- `iter_hook(strat, model, i)`
+- `finished(strat, model, i)`
+- `update!(model, strat, item)`
+"""
 abstract type LearningStrategy end
 
 # fallbacks don't do anything
@@ -36,7 +33,7 @@ pre_hook(strat::LearningStrategy, model)      = return
 iter_hook(strat::LearningStrategy, model, i)  = return
 post_hook(strat::LearningStrategy, model)     = return
 finished(strat::LearningStrategy, model, i)   = false
-learn!(model, strat::LearningStrategy, data)  = return
+update!(model, strat::LearningStrategy, item) = return
 
 # ----------------------------------------------------------------------
 

--- a/src/metalearner.jl
+++ b/src/metalearner.jl
@@ -89,3 +89,9 @@ function make_learner(args...; kw...)
     end
     MetaLearner(args..., strats...)
 end
+
+
+# add to an existing meta
+function make_learner(meta::MetaLearner, args...; kw...)
+    make_learner(meta.managers..., args...; kw...)
+end

--- a/src/metalearner.jl
+++ b/src/metalearner.jl
@@ -50,16 +50,14 @@ end
 
 
 # return nothing forever
-type InfiniteNothing end
+struct InfiniteNothing end
 Base.start(itr::InfiniteNothing) = 1
 Base.done(itr::InfiniteNothing, i) = false
 Base.next(itr::InfiniteNothing, i) = (nothing, i+1)
 
 
 # we can optionally learn without input data... good for minimizing functions
-function learn!(model, meta::MetaLearner)
-    learn!(model, meta, InfiniteNothing())
-end
+learn!(model, meta::MetaLearner) = learn!(model, meta, InfiniteNothing())
 
 # TODO: can we instead use generated functions for each MetaLearner callback so that they are ONLY called for
 #   those methods which the manager explicitly implements??  We'd need to have a type-stable way

--- a/src/metalearner.jl
+++ b/src/metalearner.jl
@@ -4,7 +4,7 @@
 
 A Meta-learner which joins learning strategies in a type-stable way.
 """
-type MetaLearner{MGRS <: Tuple} <: LearningStrategy
+struct MetaLearner{MGRS <: Tuple} <: LearningStrategy
     managers::MGRS
 end
 
@@ -90,9 +90,4 @@ function make_learner(args...; kw...)
         end
     end
     MetaLearner(args..., strats...)
-end
-
-# add to an existing meta
-function make_learner(meta::MetaLearner, args...; kw...)
-    make_learner(meta.managers..., args...; kw...)
 end

--- a/src/strategies.jl
+++ b/src/strategies.jl
@@ -82,7 +82,7 @@ post_hook(strat::Converged, model) = info()
     ConvergedTo(f, goal; tol=1e-6, every=1)
 Stop learning when `‖f(model) - goal‖ ≦ tol`.
 """
-type ConvergedTo{V} <: LearningStrategy
+struct ConvergedTo{V} <: LearningStrategy
     f::Function   # f(model)
     tol::Float64  # normdiff tolerance
     goal::V       # goal value
@@ -122,7 +122,7 @@ end
     Tracer{T}(::Type{T}, f, b=1)
 Store `f(model, i)` every `b` iterations.
 """
-type Tracer{S} <: LearningStrategy
+struct Tracer{S} <: LearningStrategy
     every::Int
     f::Function
     storage::Vector{S}

--- a/src/strategies.jl
+++ b/src/strategies.jl
@@ -40,6 +40,7 @@ ShowStatus(every::Int = 1) = ShowStatus(every, (model, i) -> "Iteration $i: $(pa
 pre_hook(strat::ShowStatus, model) = iter_hook(strat, model, 0)
 function iter_hook(strat::ShowStatus, model, i)
     mod1(i, strat.every) == strat.every && println(strat.f(model, i))
+    return
 end
 
 #-----------------------------------------------------------------------# ConvergenceFunction
@@ -50,14 +51,14 @@ Stop learning when `f(model, i)` returns true.
 struct ConvergenceFunction <: LearningStrategy
     f::Function
 end
-finished(strat::ConvergenceFunction, model, i) = strat.f(model, i)
+finished(strat::ConvergenceFunction, model, i)::Bool = strat.f(model, i)
 
 #-----------------------------------------------------------------------# Converged
 """
     Converged(f; tol = 1e-6, every = 1)
 Stop learning when `norm(f(model) - lastf) ≦ tol`.
 """
-struct Converged <: LearningStrategy
+mutable struct Converged <: LearningStrategy
     f::Function   # f(model)
     tol::Float64  # normdiff tolerance
     every::Int    # only check every ith iteration
@@ -75,7 +76,7 @@ function finished(strat::Converged, model, i)
         false
     end
 end
-post_hook(strat::Converged, model) = info()
+post_hook(strat::Converged, model) = info("Not converged: $(strat.lastval)")
 
 #-----------------------------------------------------------------------# ConvergedTo
 """
@@ -115,6 +116,7 @@ function iter_hook(strat::IterFunction, model, i)
     if mod1(i, strat.every) == strat.every
         strat.f(model, i)
     end
+    return
 end
 
 #-----------------------------------------------------------------------# Tracer

--- a/src/strategies.jl
+++ b/src/strategies.jl
@@ -1,15 +1,20 @@
-
-"A sub-strategy to stop the learning after a fixed number of iterations (maxiter)"
-immutable MaxIter <: LearningStrategy
+#-----------------------------------------------------------------------# MaxIter
+"""
+    MaxIter(n)
+Stop learning after `n` iterations.
+"""
+struct MaxIter <: LearningStrategy
     maxiter::Int
 end
 MaxIter() = MaxIter(100)
 finished(strat::MaxIter, model, i) = i >= strat.maxiter
 
-# -------------------------------------------------------------
-
-"Stop iterating after a pre-determined amount of time."
-type TimeLimit <: LearningStrategy
+#-----------------------------------------------------------------------# TimeLimit
+"""
+    TimeLimit(s)
+Stop iterating after `s` seconds.
+"""
+mutable struct TimeLimit <: LearningStrategy
     secs::Float64
     secs_end::Float64
     TimeLimit(secs::Number) = new(secs)
@@ -17,41 +22,42 @@ end
 pre_hook(strat::TimeLimit, model) = (strat.secs_end = time() + strat.secs)
 function finished(strat::TimeLimit, model, i)
     stop = time() >= strat.secs_end
-    if stop
-        info("Time's up!")
-    end
+    stop && info("Time's up!")
     stop
 end
 
-# -------------------------------------------------------------
-
-"Print out a summary of the current learning"
-type ShowStatus <: LearningStrategy
+#-----------------------------------------------------------------------# ShowStatus
+"""
+    ShowStatus(b=1)
+    ShowStatus(b, f)
+Every `b` iterations, print the output of `f(model, i)`.
+"""
+struct ShowStatus <: LearningStrategy
     every::Int
     f::Function
 end
 ShowStatus(every::Int = 1) = ShowStatus(every, (model, i) -> "Iteration $i: $(params(model))")
-
 pre_hook(strat::ShowStatus, model) = iter_hook(strat, model, 0)
 function iter_hook(strat::ShowStatus, model, i)
-    if mod1(i, strat.every) == strat.every
-        println(strat.f(model, i))
-    end
-    return
+    mod1(i, strat.every) == strat.every && println(strat.f(model, i))
 end
 
-# -------------------------------------------------------------
-
-"A sub-strategy to stop learning when the associated function returns true."
-immutable ConvergenceFunction <: LearningStrategy
+#-----------------------------------------------------------------------# ConvergenceFunction
+"""
+    ConvergenceFunction(f)
+Stop learning when `f(model, i)` returns true.
+"""
+struct ConvergenceFunction <: LearningStrategy
     f::Function
 end
 finished(strat::ConvergenceFunction, model, i) = strat.f(model, i)
 
-# -------------------------------------------------------------
-
-"Finished when `‖f(model) - lastf‖ ≦ tol`"
-type Converged <: LearningStrategy
+#-----------------------------------------------------------------------# Converged
+"""
+    Converged(f; tol = 1e-6, every = 1)
+Stop learning when `norm(f(model) - lastf) ≦ tol`.
+"""
+struct Converged <: LearningStrategy
     f::Function   # f(model)
     tol::Float64  # normdiff tolerance
     every::Int    # only check every ith iteration
@@ -69,10 +75,13 @@ function finished(strat::Converged, model, i)
         false
     end
 end
+post_hook(strat::Converged, model) = info()
 
-# -------------------------------------------------------------
-
-"Finished when `‖f(model) - goal‖ ≦ tol`"
+#-----------------------------------------------------------------------# ConvergedTo
+"""
+    ConvergedTo(f, goal; tol=1e-6, every=1)
+Stop learning when `‖f(model) - goal‖ ≦ tol`.
+"""
 type ConvergedTo{V} <: LearningStrategy
     f::Function   # f(model)
     tol::Float64  # normdiff tolerance
@@ -92,10 +101,11 @@ function finished(strat::ConvergedTo, model, i)
     end
 end
 
-# -------------------------------------------------------------
-
-
-"A sub-strategy to do something each iteration."
+#-----------------------------------------------------------------------# IterFunction
+"""
+    IterFunction(f, b=1)
+Call `f(model, i)` every `b` iterations.
+"""
 immutable IterFunction <: LearningStrategy
     f::Function
     every::Int
@@ -105,12 +115,13 @@ function iter_hook(strat::IterFunction, model, i)
     if mod1(i, strat.every) == strat.every
         strat.f(model, i)
     end
-    return
 end
 
-# -------------------------------------------------------------
-
-"Store something every ith iteration"
+#-----------------------------------------------------------------------# Tracer
+"""
+    Tracer{T}(::Type{T}, f, b=1)
+Store `f(model, i)` every `b` iterations.
+"""
 type Tracer{S} <: LearningStrategy
     every::Int
     f::Function

--- a/src/strategies.jl
+++ b/src/strategies.jl
@@ -107,7 +107,7 @@ end
     IterFunction(f, b=1)
 Call `f(model, i)` every `b` iterations.
 """
-immutable IterFunction <: LearningStrategy
+struct IterFunction <: LearningStrategy
     f::Function
     every::Int
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,12 +2,41 @@ module LearningStrategiesTest
 using LearningStrategies
 using Base.Test
 
-add_one!(m, i) = (m[1] += 1)
+
+
+
+strat_list = [
+    MaxIter(20),
+    TimeLimit(2),
+    ShowStatus(1, (m, i) -> "$m after $i iterations"),
+    ConvergenceFunction((m, i) -> true),
+    Converged(m -> m),
+    ConvergedTo(m -> m, ones(2)),
+    IterFunction((m, i) -> println("this is iteration $i")),
+    Tracer(Float64, (m, i) -> mean(m))
+]
+@testset "Type stability" begin
+    m = ones(2)
+    i = 5
+    for s in strat_list
+        println("  > ", s)
+        # println("    - ", "pre_hook")
+        @inferred pre_hook(s, m)
+        # println("    - ", "post_hook")
+        @inferred post_hook(s, m)
+        # println("    - ", "iter_hook")
+        @inferred iter_hook(s, m, i)
+        # println("    - ", "finished")
+        @inferred finished(s, m, i)
+        # println("    - ", "update!")
+        @inferred update!(m, s, i)
+    end
+end
 
 @testset "MaxIter/IterFunction" begin
     model = [0]
-    s = make_learner(MaxIter(20), IterFunction(add_one!))
-    learn!(model, s)
+    s = make_learner(MaxIter(20), IterFunction((m,i) -> (m[1] += 1)))
+    @inferred learn!(model, s)
     @test model[1] == 20
 end
 
@@ -15,7 +44,7 @@ end
     model = nothing
     s = make_learner(TimeLimit(2))
     t1 = time()
-    learn!(model, s)
+    @inferred learn!(model, s)
     elapsed = time() - t1
     @test elapsed < 3
 end
@@ -23,13 +52,38 @@ end
 @testset "ShowStatus" begin
     model = nothing
     s = make_learner(MaxIter(2), ShowStatus(1, (m, i) -> "    model is still $model"))
-    learn!(model, s)
+    @inferred learn!(model, s)
 end
 
 @testset "ConvergenceFunction" begin
     model = nothing
     s = make_learner(ConvergenceFunction((m,i) -> true))
-    learn!(model, s)
+    @inferred learn!(model, s)
+end
+
+@testset "Converged" begin
+    model = ones(5)
+    s = make_learner(Converged(m -> m))
+    @inferred learn!(model, s)
+end
+
+@testset "ConvergedTo" begin
+    model = ones(5)
+    s = make_learner(ConvergedTo(m -> m, ones(5)))
+    @inferred learn!(model, s)
+end
+
+@testset "IterFunction" begin
+    model = ones(5)
+    s = make_learner(MaxIter(2), IterFunction((m,i) -> println("    print 2 times!")))
+    @inferred learn!(model, s)
+end
+
+@testset "Tracer" begin
+    model = 1.0
+    s = make_learner(MaxIter(3), Tracer(Float64, (m,i) -> m))
+    @inferred learn!(model, s)
+    @test s.managers[2].storage == ones(3)
 end
 
 


### PR DESCRIPTION
- julia0.6-pre -> julia0.6
- immutable/type -> struct/mutable struct
- Cleaned up docstrings
- Changed `learn!` to `update!` inside the main loop.  This makes a distinction:
  - `update!` implements a single iteration
  - `learn!` runs at least one iteration according to MetaLearner
- Made MetaLearner immutable (should it be mutable?)
- Ability to send data to a MetaLearner in an online or offline fashion.  Ex:
```julia
learn!(model, meta, data, LearnType.Offline())
```