### PR TITLE
Linked warwick-rsg notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 **LearningStrategies is a modular framework for building iterative algorithms in Julia**.
 
+Below, some of the key concepts are briefly explained, and a few examples are made. A more in-depth notebook can be found [here](http://nbviewer.jupyter.org/github/dominusmi/warwick-rsg/blob/master/Educational/LearningStrategies.ipynb)
+
 ## Basics
 
 Many algorithms can be generalized to the following pseudocode:


### PR DESCRIPTION
Continuing from #21 , I _prominently linked_ the notebook at the top of the README.md, just added a small sentence :slightly_smiling_face: 
An alternative could also be to move the whole notebook directly to this repository if preferred. 
Obviously feel free to edit :+1: 